### PR TITLE
Bump httpclient from 4.5.2 to 4.5.13 in /inbound-invites-repo

### DIFF
--- a/inbound-invites-repo/pom.xml
+++ b/inbound-invites-repo/pom.xml
@@ -134,7 +134,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Bumps httpclient from 4.5.2 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:development ...